### PR TITLE
Adding comment handling with hash characters

### DIFF
--- a/languages/groovy/src/main/groovy/org/m3/hron/HronParser.groovy
+++ b/languages/groovy/src/main/groovy/org/m3/hron/HronParser.groovy
@@ -82,7 +82,8 @@ class HronParser {
   }
 
   private void parseLine(String line, HronParseState state) {
-    if (!line) return
+    //ignore empty/null lines and lines starting with our the comment character
+    if (!line || line[0] == '#') return
 
     int indent = 0
     Character first = line.chars.find { char c ->
@@ -107,6 +108,10 @@ class HronParser {
         if (indent < state.currentIndent) state.popUntilIndent(indent)
 
         state.openObject line[(indent+1)..-1]
+        break
+
+      case '#':
+        //a comment line, we ignore this and boldly go forth with the next line
         break
 
       default:

--- a/languages/groovy/src/test/groovy/org/m3/hron/HronParserSpecification.groovy
+++ b/languages/groovy/src/test/groovy/org/m3/hron/HronParserSpecification.groovy
@@ -94,4 +94,36 @@ class HronParserSpecification  extends Specification  {
       multiLine[2] == ""
       multiLine[3] == "Third line"
   }
+
+  def "should ignore comment lines for simple hron blob"() {
+    given:
+      String hron =   """|#######################################
+                         |# I am a comment line on the root level
+                         |@bean
+                         |	=propOne
+                         |		valueOne
+                         |	######################################################
+                         |	# I am a comment line at the current indentation level
+                         |	=propTwo
+                         |#######################################
+                         |# And a comment inserted straight into the flow
+                         |		valueTwo
+                         |	=propThree
+                         |		multi-line string value
+                         |	# with a indent-level comment injected and ignored
+                         |# and a root-level comment injected and ignored
+                         |		second line of multi-line string value
+                         |""".stripMargin()
+
+    when:
+      Map result = parser.parseText(hron) as Map
+
+    then:
+      result.bean.size() == 3
+      result.bean.propOne == 'valueOne'
+      result.bean.propTwo == 'valueTwo'
+      result.bean.propThree.readLines().size() == 2
+      result.bean.propThree.readLines()[0] == "multi-line string value"
+      result.bean.propThree.readLines()[1] == "second line of multi-line string value"
+  }
 }


### PR DESCRIPTION
adding comment handling for root-level and indent-level hash characters. Works in multi-line strings etc also
