### PR TITLE
removing error in spock specification

### DIFF
--- a/languages/groovy/src/test/groovy/org/m3/hron/HronParserSpecification.groovy
+++ b/languages/groovy/src/test/groovy/org/m3/hron/HronParserSpecification.groovy
@@ -49,7 +49,7 @@ class HronParserSpecification  extends Specification  {
                       |\t=propOne
                       |\t\t\tvalue
                       |\t=propTwo
-                      |\tx\tfirst line
+                      |\t\tfirst line
                       |\t\t\tsecond line
                       |\t\t
                       |\t\t


### PR DESCRIPTION
Left in a negative test which was failing the test run
